### PR TITLE
hack spawn and spawnSync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.6.0
 
-(Work in Progress)
+* hack spawn and spawnSync: https://github.com/enclose-io/compiler/pull/10
 
 ## v0.5.0
 

--- a/vendor/node-v6.9.1/lib/child_process.js
+++ b/vendor/node-v6.9.1/lib/child_process.js
@@ -377,6 +377,15 @@ var spawn = exports.spawn = function(/*file, args, options*/) {
 
   debug('spawn', opts.args, options);
 
+  if (opts.file === process.execPath ||
+      -1 !== opts.args.join().indexOf(process.execPath)) {
+    if (!opts.options.env) {
+      opts.options.env = Object.create( process.env );
+    }
+    opts.options.env.ENCLOSE_IO_USE_ORIGINAL_NODE = '1';
+    opts.envPairs.push('ENCLOSE_IO_USE_ORIGINAL_NODE=1');
+  }
+
   child.spawn({
     file: opts.file,
     args: opts.args,
@@ -406,6 +415,15 @@ function lookupSignal(signal) {
 
 function spawnSync(/*file, args, options*/) {
   var opts = normalizeSpawnArguments.apply(null, arguments);
+
+  if (opts.file === process.execPath ||
+      -1 !== opts.args.join().indexOf(process.execPath)) {
+    if (!opts.options.env) {
+      opts.options.env = Object.create( process.env );
+    }
+    opts.options.env.ENCLOSE_IO_USE_ORIGINAL_NODE = '1';
+    opts.envPairs.push('ENCLOSE_IO_USE_ORIGINAL_NODE=1');
+  }
 
   var options = opts.options;
 

--- a/vendor/node-v7.1.0/lib/child_process.js
+++ b/vendor/node-v7.1.0/lib/child_process.js
@@ -382,6 +382,15 @@ var spawn = exports.spawn = function(/*file, args, options*/) {
 
   debug('spawn', opts.args, options);
 
+  if (opts.file === process.execPath ||
+      -1 !== opts.args.join().indexOf(process.execPath)) {
+    if (!opts.options.env) {
+      opts.options.env = Object.create( process.env );
+    }
+    opts.options.env.ENCLOSE_IO_USE_ORIGINAL_NODE = '1';
+    opts.envPairs.push('ENCLOSE_IO_USE_ORIGINAL_NODE=1');
+  }
+
   child.spawn({
     file: opts.file,
     args: opts.args,
@@ -411,6 +420,15 @@ function lookupSignal(signal) {
 
 function spawnSync(/*file, args, options*/) {
   var opts = normalizeSpawnArguments.apply(null, arguments);
+
+  if (opts.file === process.execPath ||
+      -1 !== opts.args.join().indexOf(process.execPath)) {
+    if (!opts.options.env) {
+      opts.options.env = Object.create( process.env );
+    }
+    opts.options.env.ENCLOSE_IO_USE_ORIGINAL_NODE = '1';
+    opts.envPairs.push('ENCLOSE_IO_USE_ORIGINAL_NODE=1');
+  }
 
   var options = opts.options;
 


### PR DESCRIPTION
cc @shaoshuai0102 

- spawn(options.execPath, args, options)
    -> options.execPath include? process.execPath then options.env << ENCLOSE_IO_USE_ORIGINAL_NODE
- spawnSync(command[, args][, options])
    -> command include? process.execPath then options.env << ENCLOSE_IO_USE_ORIGINAL_NODE
